### PR TITLE
update ava to version 2.1.0 and remove support for Node.js < v8

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	"devDependencies": {
 		"@types/meow": "^5.0.0",
 		"@types/node": "^11.13.8",
-		"ava": "^1.1.0",
+		"ava": "^2.1.0",
 		"prettier": "^1.16.4",
 		"typescript": "^3.3.3333"
 	}


### PR DESCRIPTION
Closes #5